### PR TITLE
try to respect read-only filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV HOME=/root
 ENV OLLAMA_KEEP_ALIVE=2m
 ENV OLLAMA_REQUEST_TIMEOUT=120s
 ENV OLLAMA_MAX_LOADED_MODELS=4
+# Point models to the pre-built location (read-only)
+ENV OLLAMA_MODELS=/root/.ollama/models
 
 RUN curl -fsSL https://ollama.com/install.sh | bash
 
@@ -36,6 +38,10 @@ RUN ollama serve & \
     ollama pull qwen2.5-coder:1.5b && \
     kill $OLLAMA_PID && \
     wait $OLLAMA_PID 2>/dev/null || true
+
+# After models are pulled, switch OLLAMA_HOME to /tmp for runtime
+ENV OLLAMA_HOME=/tmp/.ollama
+
 EXPOSE 11434
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
-# Models are already pre-pulled in the Docker image during build
-# Just start Ollama server directly
+# Models are already pre-pulled in the Docker image during build at /root/.ollama/models
+# OLLAMA_HOME is set to /tmp/.ollama for runtime data (logs, state, etc.)
+# Create the tmp directory (needed because /tmp is mounted as emptyDir in nais.yaml)
+mkdir -p /tmp/.ollama
+
+# Start Ollama server
 exec ollama serve

--- a/nais.yaml
+++ b/nais.yaml
@@ -48,6 +48,10 @@ spec:
     min: 1
     max: 3
     cpuThresholdPercentage: 80
+  filesFrom:
+    - emptyDir:
+        medium: Memory
+      mountPath: /tmp
   ingresses:
     - "https://ollama.ansatt.nav.no"
     - "https://ollama.intern.nav.no"

--- a/tooling/bruno/test.bru
+++ b/tooling/bruno/test.bru
@@ -4,12 +4,25 @@ meta {
   seq: 1
 }
 
-get {
-  url: 127.0.0.1:11434
-  body: none
+post {
+  url: 127.0.0.1:11434/api/chat
+  body: json
   auth: inherit
+}
+
+body:json {
+  {
+      "model": "tinyllama:1.1b",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Hello, how are you?"
+        }
+      ]
+    }
 }
 
 settings {
   encodeUrl: true
+  timeout: 0
 }


### PR DESCRIPTION
comment about it for the mkdir (probably only requirement to run at runtime within the entrypoint.sh, it should happen after nais has done the tempfs mounting stuff for /tmp)

the OLLAMA_MODELS should let us have a different directory for the actual models being stored.